### PR TITLE
Add View Helper to read an item's enclosure data

### DIFF
--- a/Classes/Backend/TceForms.php
+++ b/Classes/Backend/TceForms.php
@@ -44,9 +44,9 @@ class TceForms
 
             $selectedItem = '';
             if (!empty($params['row']['pi_flexform'])) {
-                $values = $params['row']['pi_flexform'];
-                if (!empty($values['data']['sDEF']['lDEF']['settings.template'])) {
-                    $selectedItem = $values['data']['sDEF']['lDEF']['settings.template']['vDEF'];
+                $flexform = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($params['row']['pi_flexform']);
+                if (!empty($flexform['data']['sDEF']['lDEF']['settings.template'])) {
+                    $selectedItem = $flexform['data']['sDEF']['lDEF']['settings.template']['vDEF'];
                 }
             }
 

--- a/Classes/ViewHelpers/Item/EnclosureViewHelper.php
+++ b/Classes/ViewHelpers/Item/EnclosureViewHelper.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+
+/**
+ * A View Helper which returns the enclosure of a SimplePie item.
+ */
+class Tx_RssDisplay_ViewHelpers_Item_EnclosureViewHelper extends AbstractViewHelper
+{
+
+    /**
+     * Retrieve the SimplePie item from the context and return its enclosure data.
+     *
+     * @param string $attribute The attribute to retrieve. Must be either "url", "length" or "type".
+     * @return null|string Returns null, if no enclosure can be found or the attribute data requested.
+     */
+    public function render($attribute)
+    {
+        if (!in_array($attribute, array('url', 'length', 'type'))) {
+            $message = sprintf('Attribute "%s" is no valid enclosure attribute.', $attribute);
+            throw new \Exception($message, 1463069269);
+        }
+        
+        /** @var SimplePie_Item $item */
+        $item = $this->templateVariableContainer->get('item');
+        $data = null;
+        
+        if ($simplePieEnclosure = $item->get_enclosure()) {
+            $enclosure = array(
+                'url' => $simplePieEnclosure->get_link(),
+                'length' => $simplePieEnclosure->get_length(),
+                'type' => $simplePieEnclosure->get_type()
+            );
+            
+            $data = $enclosure[$attribute];
+        }
+
+        return $data;
+    }
+
+}

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,12 @@ Some advanced View Helpers are explains below ::
 	<f:for each="{feed:item.tags(namespace: 'http://purl.org/dc/elements/1.1/' tag: 'bar')}" as="value">
 		{value}
 	</f:for>
+	
+	# Display an enclosed image
+	<f:if condition="{feed:item.enclosure(attribute:'url')}">
+		<img src="{feed:item.enclosure(attribute:'url')}" alt>
+	</f:if>
+
 	{namespace feed=Tx_RssDisplay_ViewHelpers}
 
 


### PR DESCRIPTION
I just needed that today and from what I can see this isn't possible with the tools the extension provides right now. Any obligations?
