### PR TITLE
Use only double quotes for wrapping of HTML attributes.

### DIFF
--- a/Resources/Private/Templates/Feed/Show.html
+++ b/Resources/Private/Templates/Feed/Show.html
@@ -8,7 +8,7 @@
 
 <f:section name="content">
 	<h2>
-		<a href="{titleLink}" target='_blank'>{title}</a>
+		<a href="{titleLink}" target="_blank">{title}</a>
 	</h2>
 
 	<ul class="tx-rssdisplay-list">

--- a/Resources/Private/Templates/Feed/ShowWithCroppedDescription.html
+++ b/Resources/Private/Templates/Feed/ShowWithCroppedDescription.html
@@ -8,7 +8,7 @@
 
 <f:section name="content">
 	<h2>
-		<a href="{titleLink}" target='_blank'>{title}</a>
+		<a href="{titleLink}" target="_blank">{title}</a>
 	</h2>
 
 	<ul class="tx-rssdisplay-list">

--- a/Resources/Private/Templates/Feed/ShowWithoutDescription.html
+++ b/Resources/Private/Templates/Feed/ShowWithoutDescription.html
@@ -8,7 +8,7 @@
 
 <f:section name="content">
 	<h2>
-		<a href="{titleLink}" target='_blank'>{title}</a>
+		<a href="{titleLink}" target="_blank">{title}</a>
 	</h2>
 
 	<ul class="tx-rssdisplay-list">


### PR DESCRIPTION
Not a bug, but consistency is good.