### PR TITLE
[BUGFIX] Load ts in backend context from the right page

### DIFF
--- a/Classes/Backend/TceForms.php
+++ b/Classes/Backend/TceForms.php
@@ -31,7 +31,18 @@ class TceForms
 
         $configurationManager = $this->getObjectManager()->get(BackendConfigurationManager::class);
 
+        // fake GET[id] to get the ts configuration from the right page
+        $saveGet = null;
+        if (isset($_GET['id'])) {
+            $saveGet = $_GET['id'];
+        }
+        $_GET['id'] = $params['row']['pid'];
         $setup = $configurationManager->getTypoScriptSetup();
+        if ($saveGet !== null) {
+            $_GET['id'] = $saveGet;
+        } else {
+            unset($_GET['id']);
+        }
         $configuration = $this->getPluginConfiguration($setup, 'rssdisplay');
 
         $output = '';


### PR DESCRIPTION
We fake GET id here to trick the extbase BackendConfigurationManager.
It uses the first found site root fetching the ts if no id present.