### PR TITLE
[BUGFIX] add version-condition for TYPO3 version 9+

### DIFF
--- a/Classes/Controller/FeedController.php
+++ b/Classes/Controller/FeedController.php
@@ -143,13 +143,19 @@ class FeedController extends ActionController
      */
     protected function getPluginType()
     {
-        try {
-            $pluginType = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ExtensionConfiguration::class)
-                ->get('rss_display', 'plugin_type');
-        } catch (ExtensionConfigurationExtensionNotConfiguredException $e) {
-            $pluginType = self::PLUGIN_TYPE_USER_INT;
-        } catch (ExtensionConfigurationPathDoesNotExistException $e) {
-            $pluginType = self::PLUGIN_TYPE_USER_INT;
+        if ( \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000) {
+            try {
+                $pluginType = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                    ->get('rss_display', 'plugin_type');
+            } catch (ExtensionConfigurationExtensionNotConfiguredException $e) {
+                $pluginType = self::PLUGIN_TYPE_USER_INT;
+            } catch (ExtensionConfigurationPathDoesNotExistException $e) {
+                $pluginType = self::PLUGIN_TYPE_USER_INT;
+            }
+        } else {
+            $configurationUtility = $this->objectManager->get(ConfigurationUtility::class);
+            $configuration = $configurationUtility->getCurrentConfiguration('rss_display');
+            $pluginType = $configuration['plugin_type']['value'];
         }
 
         return $pluginType;


### PR DESCRIPTION
Release 4.2.0 got compatibility for TYPO3 version 9 but lost support for version 8 
because of the newly introduced class ExtensionConfiguration which is not available before v9.

This will resolve #33 