### PR TITLE
fixes upstream #36

### DIFF
--- a/Classes/ViewHelpers/Item/ContentViewHelper.php
+++ b/Classes/ViewHelpers/Item/ContentViewHelper.php
@@ -9,7 +9,7 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns the "content" of a SimplePie item.

--- a/Classes/ViewHelpers/Item/GetViewHelper.php
+++ b/Classes/ViewHelpers/Item/GetViewHelper.php
@@ -9,7 +9,7 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns a "tag" of a SimplePie item.

--- a/Classes/ViewHelpers/Item/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Item/LinkViewHelper.php
@@ -9,7 +9,7 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns the "link" of a SimplePie item.

--- a/Classes/ViewHelpers/Item/TagViewHelper.php
+++ b/Classes/ViewHelpers/Item/TagViewHelper.php
@@ -9,14 +9,20 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns a "tag" of a SimplePie item.
  */
 class TagViewHelper extends AbstractViewHelper
 {
+
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('namespace', 'string', 'RSS element namespace', true);
+        $this->registerArgument('tag', 'string', 'RSS element name', true);
+    }
 
     /**
      * Retrieve the SimplePie item from the context and return its "tag".
@@ -27,12 +33,12 @@ class TagViewHelper extends AbstractViewHelper
      * @return string
      * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
-    public function render($namespace, $tag)
+    public function render()
     {
 
         /** @var SimplePie_Item $item */
         $item = $this->templateVariableContainer->get('item');
-        $values = $item->get_item_tags($namespace, $tag);
+        $values = $item->get_item_tags($this->arguments['namespace'], $this->arguments['tag']);
 
         $result = '';
         if (is_array($values)) {

--- a/Classes/ViewHelpers/Item/TagsViewHelper.php
+++ b/Classes/ViewHelpers/Item/TagsViewHelper.php
@@ -9,7 +9,7 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns multiple "tags" of a SimplePie item.
@@ -17,21 +17,26 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 class TagsViewHelper extends AbstractViewHelper
 {
 
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('namespace', 'string', 'RSS element namespace', true);
+        $this->registerArgument('tag', 'string', 'RSS element name', true);
+    }
+
     /**
      * Retrieve the SimplePie item from the context and return its "tags".
      * Example of namespace: http://purl.org/dc/elements/1.1/
      *
-     * @param string $namespace
-     * @param string $tag
      * @return array
      * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
-    public function render($namespace, $tag)
+    public function render()
     {
 
         /** @var SimplePie_Item $item */
         $item = $this->templateVariableContainer->get('item');
-        $values = $item->get_item_tags($namespace, $tag);
+        $values = $item->get_item_tags($this->arguments['namespace'], $this->arguments['tag']);
 
         $result = array();
         if (is_array($values)) {

--- a/Classes/ViewHelpers/Item/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Item/TitleViewHelper.php
@@ -9,7 +9,7 @@ namespace Fab\RssDisplay\ViewHelpers\Item;
  */
 
 use SimplePie_Item;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * A View Helper which returns the "title" of a SimplePie item.


### PR DESCRIPTION
I additionally updated the namespace of Fluid's AbstractViewHelper.

`TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper` is deprecated since Typo3 9.5
`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper` has been around since Typo 8.x

So if you require Typo3 9.x for this update, it should work.