### PR TITLE
Cope with links that have ampersands encoded

### DIFF
--- a/Classes/ViewHelpers/Item/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Item/LinkViewHelper.php
@@ -28,7 +28,7 @@ class LinkViewHelper extends AbstractViewHelper
 
         /** @var SimplePie_Item $item */
         $item = $this->templateVariableContainer->get('item');
-        return $item->get_link();
+        return htmlspecialchars_decode($item->get_link());
     }
 
 }


### PR DESCRIPTION
Imagine a feed link that has url parameters. Ampersands in this case have to be encoded. & has to be &amp; in the url.
For example an article with link tag
<link>https://www.domain.com/index.php?paramname1=a&amp;paramname2=b</link>

If the ampersand is not encoded, it would not be a valid RSS feed.

The Simplepie get_link() method returns the url as is. This is used in the LinkViewHelper.

The fluid templates encode the link from the viewhelper. The above example would result in the following HTML markup, which is wrong
https://www.domain.com/index.php?paramname1=a&amp;amp;paramname2=b
Notice &amp; becoming &amp;amp;

The proposed change passes the Simplepie link through htmlspecialchars_decode before returning it to the fluid template.