### PR TITLE
Update for TYPO3 v10

### DIFF
--- a/Classes/Backend/Wizard.php
+++ b/Classes/Backend/Wizard.php
@@ -35,7 +35,7 @@ class Wizard
     }
 
     /**
-     * @return \TYPO3\CMS\Lang\LanguageService
+     * @return \TYPO3\CMS\Core\Localization\LanguageService
      */
     protected function getLanguageService()
     {

--- a/Classes/ViewHelpers/Item/ContentViewHelper.php
+++ b/Classes/ViewHelpers/Item/ContentViewHelper.php
@@ -21,7 +21,6 @@ class ContentViewHelper extends AbstractViewHelper
      * Retrieve the SimplePie item from the context and return its "content".
      *
      * @return string
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function render()
     {

--- a/Classes/ViewHelpers/Item/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Item/LinkViewHelper.php
@@ -21,7 +21,6 @@ class LinkViewHelper extends AbstractViewHelper
      * Retrieve the SimplePie item from the context and return its "link".
      *
      * @return string
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function render()
     {

--- a/Classes/ViewHelpers/Item/TagViewHelper.php
+++ b/Classes/ViewHelpers/Item/TagViewHelper.php
@@ -31,7 +31,6 @@ class TagViewHelper extends AbstractViewHelper
      * @param string $namespace
      * @param string $tag
      * @return string
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function render()
     {

--- a/Classes/ViewHelpers/Item/TagsViewHelper.php
+++ b/Classes/ViewHelpers/Item/TagsViewHelper.php
@@ -29,7 +29,6 @@ class TagsViewHelper extends AbstractViewHelper
      * Example of namespace: http://purl.org/dc/elements/1.1/
      *
      * @return array
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function render()
     {

--- a/Classes/ViewHelpers/Item/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Item/TitleViewHelper.php
@@ -21,7 +21,6 @@ class TitleViewHelper extends AbstractViewHelper
      * Retrieve the SimplePie item from the context and return its "title".
      *
      * @return string
-     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function render()
     {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends' =>
                 [
-                    'typo3' => '9.5.0-9.5.99',
+                    'typo3' => '9.5.0-10.4.99',
                 ],
             'conflicts' =>
                 [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,7 +37,7 @@ if (false === isset($configuration['autoload_typoscript']) || true === (bool)$co
 $TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['rssdisplay']['frontend'] = \TYPO3\CMS\Core\Cache\Frontend\StringFrontend::class;
 $TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['rssdisplay']['groups'] = ['all', 'rssdisplay'];
 
-if (!\TYPO3\CMS\Core\Core\Bootstrap::usesComposerClassLoading()) {
+if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
     # Install PSR-0-compatible class autoloader for SimplePie Library in Resources/PHP/SimplePie
     spl_autoload_register(function ($class) {
 


### PR DESCRIPTION
This PR adds support for TYPO3 v10.
It replaces a removed method call and corrects some references to classes in PHPdoc.

I am still testing this in my local v10 setup, but at least it does not break the backend after installation.