### PR TITLE
Fix cache, template selection and deprecations with TYPO3 v10

### DIFF
--- a/Classes/Backend/TceForms.php
+++ b/Classes/Backend/TceForms.php
@@ -19,14 +19,13 @@ class TceForms
 {
 
     /**
-     * Render a template menu.
+     * Provide configured template entries to FlexForm.
      *
      * @param array $params
-     * @param object $tsObj
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function renderTemplateMenu(&$params, &$tsObj)
+    public function getTemplateEntries(&$params)
     {
 
         $configurationManager = $this->getObjectManager()->get(BackendConfigurationManager::class);
@@ -34,32 +33,14 @@ class TceForms
         $setup = $configurationManager->getTypoScriptSetup();
         $configuration = $this->getPluginConfiguration($setup, 'rssdisplay');
 
-        $output = '';
         if (is_array($configuration['settings']['templates'])) {
 
-            $selectedItem = '';
-            if (!empty($params['row']['pi_flexform'])) {
-                $values = $params['row']['pi_flexform'];
-                if (!empty($values['data']['sDEF']['lDEF']['settings.template'])) {
-                    $selectedItem = $values['data']['sDEF']['lDEF']['settings.template']['vDEF'];
-                }
-            }
-
-            $options = array();
+            $output = [];
             foreach ($configuration['settings']['templates'] as $template) {
-                $options[] = sprintf('<option value="%s" %s>%s</option>',
-                    $template['path'],
-                    $selectedItem == $template['path'] ? 'selected="selected"' : '',
-                    $template['label']
-                );
+                $output[] = [$template['label'], $template['path']];
             }
-
-            $output = sprintf('<select name="data[tt_content][%s][pi_flexform][data][sDEF][lDEF][settings.template][vDEF]">%s</select>',
-                $params['row']['uid'],
-                implode("\n", $options)
-            );
+            $params['items'] = $output;
         }
-        return $output;
     }
 
     /**
@@ -74,8 +55,8 @@ class TceForms
     {
         $pluginConfiguration = array();
         if (is_array($setup['plugin.']['tx_' . strtolower($extensionName) . '.'])) {
-            /** @var \TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService */
-            $typoScriptService = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Service\TypoScriptService');
+            /** @var \TYPO3\CMS\Core\TypoScript\TypoScriptService $typoScriptService */
+            $typoScriptService = GeneralUtility::makeInstance('TYPO3\CMS\Core\TypoScript\TypoScriptService');
             $pluginConfiguration = $typoScriptService->convertTypoScriptArrayToPlainArray($setup['plugin.']['tx_' . strtolower($extensionName) . '.']);
         }
         return $pluginConfiguration;

--- a/Classes/Controller/FeedController.php
+++ b/Classes/Controller/FeedController.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -122,7 +123,7 @@ class FeedController extends ActionController
         $feed = new \SimplePie();
         //external request by use of a proxy
         $feed->set_raw_data(GeneralUtility::getUrl($feedUrl));
-        $location = PATH_site . 'typo3temp';
+        $location = Environment::getPublicPath() . '/typo3temp';
         $feed->set_cache_location($location);
         $feed->init();
         return $feed;

--- a/Configuration/FlexForm/feed.xml
+++ b/Configuration/FlexForm/feed.xml
@@ -36,8 +36,10 @@
 						<TCEforms>
 							<label>LLL:EXT:rss_display/Resources/Private/Language/locallang.xlf:tt_content.tx_rssdisplay_template</label>
 							<config>
-								<type>user</type>
-								<userFunc>Fab\RssDisplay\Backend\TceForms->renderTemplateMenu</userFunc>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<itemsProcFunc>Fab\RssDisplay\Backend\TceForms->getTemplateEntries</itemsProcFunc>
+								<items></items>
 							</config>
 						</TCEforms>
 					</settings.template>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@ if (!defined('TYPO3_MODE')) die ('Access denied.');
 
 // Define whether USER or USER_INT.
 $pluginType = 'USER_INT';
-$configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['rss_display']);
+$configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['rss_display'];
 if (!empty($configuration['plugin_type'])) {
     $pluginType = $configuration['plugin_type'];
 }
@@ -34,8 +34,10 @@ if (false === isset($configuration['autoload_typoscript']) || true === (bool)$co
 
 // cache configuration, see
 // https://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/CachingFramework/Configuration/Index.html#cache-configurations
-$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['rssdisplay']['frontend'] = \TYPO3\CMS\Core\Cache\Frontend\StringFrontend::class;
-$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['rssdisplay']['groups'] = ['all', 'rssdisplay'];
+if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['rssdisplay'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['rssdisplay'] = [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['rssdisplay']['groups'] = ['all', 'rssdisplay'];
+}
 
 if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
     # Install PSR-0-compatible class autoloader for SimplePie Library in Resources/PHP/SimplePie

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -13,7 +13,7 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['rssdisplay_p
 );
 
 // Possible Static TS loading
-$configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['rss_display']);
+$configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['rss_display'];
 if (true === isset($configuration['autoload_typoscript']['value']) && true === (bool)$configuration['autoload_typoscript']['value']) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('rss_display', 'Configuration/TypoScript', 'RSS Display: display a RSS / Atom feed');
 }


### PR DESCRIPTION
As a follow-up to #49, this PR resolves cache and template selection issues (#50), as well as quickly fixable deprecations from the extension scanner.

Fixes: #50 