### PR TITLE
[BUGFIX] Replace deprecated constant with getPublicPath method

### DIFF
--- a/Classes/Controller/FeedController.php
+++ b/Classes/Controller/FeedController.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -122,7 +123,7 @@ class FeedController extends ActionController
         $feed = new \SimplePie();
         //external request by use of a proxy
         $feed->set_raw_data(GeneralUtility::getUrl($feedUrl));
-        $location = PATH_site . 'typo3temp';
+        $location = Environment::getPublicPath() . '/typo3temp';
         $feed->set_cache_location($location);
         $feed->init();
         return $feed;


### PR DESCRIPTION
`PATH_site` is deprecated and causes warnings/exceptions in TYPO3 v10 installations. This replaces the constant call with `Environment::getPublicPath()` to prevent those errors.