### PR TITLE
Add requirement for TYPO3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
             "SimplePie": "Resources/Private/PHP/SimplePie/"
         }
     },
+    "require": {
+        "typo3/cms-core": "^10.4.0"
+    },
     "replace": {
         "fab/rss_display": "self.version",
         "typo3-ter/rss-display": "self.version"


### PR DESCRIPTION
Add a requirement for TYPO3 in composer.json so that supported
TYPO3 version is specified.

Resolves: #58