### PR TITLE
Add extension-key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,11 @@
         }
     },
     "replace": {
-        "fab/rss_display": "self.version",
         "typo3-ter/rss-display": "self.version"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "rss_display"
+        }
     }
 }


### PR DESCRIPTION
It is now mandatory for extensions to specify the extension-key
in the extra section of a composer.json.

---

Not doing so will result in a warning:

The TYPO3 extension package "fab/rss-display", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
