### PR TITLE
Specify extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "replace": {
         "fab/rss_display": "self.version",
         "typo3-ter/rss-display": "self.version"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "rss_display"
+        }
     }
 }


### PR DESCRIPTION
Because this is a new requirement of TYPO3, as described in:

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra