### PR TITLE
Fix PackageStates generation on TYPO3v10

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,4 +9,9 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Fabien Udriot',
     'author_email' => 'fabien@ecodev.ch',
     'author_company' => 'Ecodev',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '10.4.0-11.5.99',
+        ],
+    ],
 ];


### PR DESCRIPTION
Generating the PackageStates.php file on TYPO3v10 did fail since the TYPO3 package manager did use "require" from the "composer.json". This can be avoided by adding "constraints/depends" to the "ext_emconf.php" which are preferred then.

Fixes #75